### PR TITLE
Enable `comma-dangle` always-multiline

### DIFF
--- a/node.js
+++ b/node.js
@@ -44,7 +44,7 @@ module.exports = {
 
   rules: {
     'no-console': off,
-    'comma-dangle': [ 1, never ],
+    'comma-dangle': [error, 'always-multiline'],
     'max-len': off,
     'no-mixed-spaces-and-tabs': error,
     'no-tabs': error,


### PR DESCRIPTION
Adds a rule to enforce dangling commas 

Trailing commas simplify adding and removing items to objects and arrays, since only the lines you are modifying must be touched. (And then, improve the number of line of codes in a review)

