### PR TITLE
tighten rule around function definition spacing

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -36,3 +36,14 @@ This project self-lints:
   npm i
   npm run lint
 ```
+
+## Releasing
+
+To release a new version, check out the code on your local machine, then:
+
+```bash
+npm version minor
+git push && git push --tags
+```
+
+Where `minor` is a sensible default for rule changes which will impact existing projects.

--- a/node.js
+++ b/node.js
@@ -43,7 +43,7 @@ module.exports = {
   },
 
   rules: {
-    'comma-dangle': [ 1, never ],
+    'comma-dangle': [ warn, never ],
     'max-len': off,
     'no-console': off,
     'no-mixed-spaces-and-tabs': error,
@@ -54,6 +54,7 @@ module.exports = {
     'object-curly-spacing': [ 0, never ],
     'quotes': [ error, single ],
     'semi': [ error, never ],
-    'space-before-function-paren': 0
+    'space-before-function-paren': [error, always],
+    'space-after-function-name': [error, always],
   }
 }

--- a/node.js
+++ b/node.js
@@ -54,7 +54,6 @@ module.exports = {
     'object-curly-spacing': [ 0, never ],
     'quotes': [ error, single ],
     'semi': [ error, never ],
-    'space-before-function-paren': [error, always],
-    'space-after-function-name': [error, always],
+    'space-before-function-paren': [ error, always ]
   }
 }

--- a/node.js
+++ b/node.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { error, never, off, single } = require('./constants')
+const { error, never, off, single, warn } = require('./constants')
 
 module.exports = {
 


### PR DESCRIPTION
Seems like we already had this as a rule, but it was silenced?

This rule means that you need to define methods as:

```javascript
function methodName (args...) {
}
```
instead of allowing
```javascript
function methodName(args...) {
}
```

For me at least, the former is much more readable.

* https://eslint.org/docs/rules/space-after-function-name