### PR TITLE
No useless constructor. 

### DIFF
--- a/node.js
+++ b/node.js
@@ -43,6 +43,7 @@ module.exports = {
   },
 
   rules: {
+    'no-useless-constructor': error,
     'comma-dangle': [ 1, never ],
     'max-len': off,
     'no-console': off,

--- a/react.js
+++ b/react.js
@@ -17,7 +17,6 @@ module.exports = {
 
   rules: {
     'jsx-quotes': [ error, 'prefer-double' ],
-    'no-useless-constructor': 2,
     'react/jsx-indent': [ 1, 2 ],
     'react/jsx-indent-props': [ 1, 2 ],
     'react/forbid-prop-types': [ 2, { 'forbid': [ any ] } ],

--- a/react.js
+++ b/react.js
@@ -17,6 +17,7 @@ module.exports = {
 
   rules: {
     'jsx-quotes': [ error, 'prefer-double' ],
+    'no-useless-constructor': 2,
     'react/jsx-indent': [ 1, 2 ],
     'react/jsx-indent-props': [ 1, 2 ],
     'react/forbid-prop-types': [ 2, { 'forbid': [ any ] } ],


### PR DESCRIPTION
Added the rule `no-useless-constructor` to `react.js`. 

The reasoning behind this is two fold. 

* First, the less code we have, the better. 

* Second, `Circle CI` enforces this rule while this local linter does not. This causes commits that look acceptable in a dev environment to fail when pushed.