### PR TITLE
Added space-infix-ops

### DIFF
--- a/node.js
+++ b/node.js
@@ -33,6 +33,7 @@ module.exports = {
 
   rules: {
     'no-useless-constructor': error,
+    'space-infix-ops': error,
     'comma-dangle': [ warn, never ],
     'max-len': off,
     'no-console': off,


### PR DESCRIPTION
Added this [rule](https://eslint.org/docs/rules/space-infix-ops)

This will prevent writing operations like `a+b`, for example.

It will also prevent writing default arguments as `function myFunction (myArg=0)`. With this rule, we must write `function myFunction (myArg = 0)`

---

[![](https://api.gh-polls.com/poll/01C91MDZ2TG2YDFFV4R862M039/Yes)](https://api.gh-polls.com/poll/01C91MDZ2TG2YDFFV4R862M039/Yes/vote)
[![](https://api.gh-polls.com/poll/01C91MDZ2TG2YDFFV4R862M039/No)](https://api.gh-polls.com/poll/01C91MDZ2TG2YDFFV4R862M039/No/vote)