### PR TITLE
React: New rule “no-multiple-empty-lines”

### DIFF
--- a/react.js
+++ b/react.js
@@ -17,7 +17,7 @@ module.exports = {
 
   rules: {
     'jsx-quotes': [ error, 'prefer-double' ],
-    'no-multiple-empty-lines': [ error, { max: 1} ],
+    'no-multiple-empty-lines': [ error, { max: 1 } ],
     'react/forbid-prop-types': [ error, { 'forbid': [ any ] } ],
     'react/jsx-boolean-value': [ off ],
     'react/jsx-indent': [ warn, 2 ],

--- a/react.js
+++ b/react.js
@@ -17,6 +17,7 @@ module.exports = {
 
   rules: {
     'jsx-quotes': [ error, 'prefer-double' ],
+    'no-multiple-empty-lines': [ error, { max: 1} ],
     'react/forbid-prop-types': [ error, { 'forbid': [ any ] } ],
     'react/jsx-boolean-value': [ off ],
     'react/jsx-indent': [ warn, 2 ],


### PR DESCRIPTION
### Work done
* Define `no-multiple-empty-lines` to stop wasting time on PR.
The majority of front end devs already do this anyway.

### Good
```js
export const hello = () => ('world')

export const foo = () => ('bar')
````

### Bad
```js
export const hello = () => ('world')


export const foo = () => ('bar')
````