### PR TITLE
React: Stop ESLINT error for PureComponent

### DIFF
--- a/react.js
+++ b/react.js
@@ -61,6 +61,6 @@ module.exports = {
     'react/no-did-update-set-state': error,
     'react/no-unused-prop-types': warn,
     'react/no-multi-comp': [ warn, { ignoreStateless: true } ],
-    'react/prefer-stateless-function': error
+    'react/prefer-stateless-function': [ error, { ignorePureComponents: true } ]
   }
 }


### PR DESCRIPTION
### GOOD
With current version of ESLINT config, the code below will give an error.
```
class Foo extends React.PureComponent {
  render() {
    return <div>{this.props.foo}</div>
  }
}
```


### BAD
As this code does not use `props` or `context`
```
class Foo extends React.PureComponent {
  render() {
    return <div>Bar</div>
  }
}
```
