### PR TITLE
No multiple spaces

### DIFF
--- a/node.js
+++ b/node.js
@@ -32,6 +32,7 @@ module.exports = {
   },
 
   rules: {
+    'no-multi-spaces': error,
     'no-useless-constructor': error,
     'space-infix-ops': error,
     'comma-dangle': [ warn, never ],
@@ -50,6 +51,7 @@ module.exports = {
     'keyword-spacing': error,
     'eol-last': [ error, always ],
     'brace-style': [ error, '1tbs', { allowSingleLine: true } ],
-    'curly': [ error, all ]
+    'curly': [ error, all ],
+    'no-console': [error, { allow: [warn, error] }]
   }
 }

--- a/node.js
+++ b/node.js
@@ -51,7 +51,6 @@ module.exports = {
     'keyword-spacing': error,
     'eol-last': [ error, always ],
     'brace-style': [ error, '1tbs', { allowSingleLine: true } ],
-    'curly': [ error, all ],
-    'no-console': [error, { allow: [debug, warn, error] }]
+    'curly': [ error, all ]
   }
 }

--- a/node.js
+++ b/node.js
@@ -52,6 +52,6 @@ module.exports = {
     'eol-last': [ error, always ],
     'brace-style': [ error, '1tbs', { allowSingleLine: true } ],
     'curly': [ error, all ],
-    'no-console': [error, { allow: [warn, error] }]
+    'no-console': [error, { allow: [debug, warn, error] }]
   }
 }

--- a/react.js
+++ b/react.js
@@ -16,6 +16,7 @@ module.exports = {
   ],
 
   rules: {
+    'no-console': [error, { allow: [debug, warn, error] }],
     'jsx-quotes': [ error, 'prefer-double' ],
     'no-multiple-empty-lines': [ error, { max: 1 } ],
     'react/forbid-prop-types': [ error, { 'forbid': [ any ] } ],

--- a/react.js
+++ b/react.js
@@ -16,7 +16,6 @@ module.exports = {
   ],
 
   rules: {
-    'no-console': [error, { allow: [debug, warn, error] }],
     'jsx-quotes': [ error, 'prefer-double' ],
     'no-multiple-empty-lines': [ error, { max: 1 } ],
     'react/forbid-prop-types': [ error, { 'forbid': [ any ] } ],


### PR DESCRIPTION
Added the following rule
* `'no-multi-spaces': error`

The purpose of the rule is to reduce minor mistakes like writing `const c` ` ` ` ` `= someValue`. The rule will catch the **multiple** spaces between `c` and `=` and will allow the developer to fix this before committing. This rule will not make `const c=someValue`, for example, the preferred way of assigning value. It will enforce a single space between tokens. 

The [rule](https://eslint.org/docs/rules/no-multi-spaces) can be found here.

---

[![](https://api.gh-polls.com/poll/01CBRY512AT5G0GFM20VMGR2ZE/Yes)](https://api.gh-polls.com/poll/01CBRY512AT5G0GFM20VMGR2ZE/Yes/vote)
[![](https://api.gh-polls.com/poll/01CBRY512AT5G0GFM20VMGR2ZE/No)](https://api.gh-polls.com/poll/01CBRY512AT5G0GFM20VMGR2ZE/No/vote)