### PR TITLE
Optional jsdoc param and return description.

### DIFF
--- a/node.js
+++ b/node.js
@@ -62,7 +62,7 @@ module.exports = {
     'no-self-compare': error,
     'no-return-assign': error,
     'no-loop-func': error,
-    'valid-jsdoc': [ warn, { requireParamDescription: false, requireReturnDescription: false} ],
+    'valid-jsdoc': [ warn, { requireParamDescription: false, requireReturnDescription: false } ],
     'for-direction': error,
     'no-buffer-constructor': error,
     'no-new-require': error,

--- a/node.js
+++ b/node.js
@@ -62,7 +62,7 @@ module.exports = {
     'no-self-compare': error,
     'no-return-assign': error,
     'no-loop-func': error,
-    'valid-jsdoc': warn,
+    'valid-jsdoc': [ warn, { requireParamDescription: false, requireReturnDescription: false} ],
     'for-direction': error,
     'no-buffer-constructor': error,
     'no-new-require': error,


### PR DESCRIPTION
The 'valid-jsdoc' by default requires description on both `parameter` and `return values`.

It's unnecessary to have a description when the parameter/return values are well-named.

Required 
```
* @param {string} contractAddress address of the contract.
* @param {string} contractName name of the contract.
```
Optional
```
* @param {string} contractAddress
* @param {string} contractName
```

<p><a href="https://api.gh-polls.com/poll/01CCAYF4KP4JRNA627WGJPXF1M/Required/vote"><img src="https://api.gh-polls.com/poll/01CCAYF4KP4JRNA627WGJPXF1M/Required" alt=""></a>
<a href="https://api.gh-polls.com/poll/01CCAYF4KP4JRNA627WGJPXF1M/Optional/vote"><img src="https://api.gh-polls.com/poll/01CCAYF4KP4JRNA627WGJPXF1M/Optional" alt=""></a></p>
