### PR TITLE
Added space-before-function-paren rule and made minor fixes

### DIFF
--- a/react.js
+++ b/react.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { warn, off, error, any, always } = require('./constants')
+const { warn, off, error, any, always, never } = require('./constants')
 
 module.exports = {
 
@@ -17,7 +17,7 @@ module.exports = {
 
   rules: {
     'jsx-quotes': [ error, 'prefer-double' ],
-    'space-before-function-paren': [ error, { 'named': always } ],
+    'space-before-function-paren': [ error, { 'named': never } ],
     'no-multiple-empty-lines': [ error, { max: 1 } ],
     'react/forbid-prop-types': [ error, { forbid: [ any ] } ],
     'react/jsx-boolean-value': [ off ],

--- a/react.js
+++ b/react.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { warn, off, error, any } = require('./constants')
+const { warn, off, error, any, always } = require('./constants')
 
 module.exports = {
 
@@ -16,14 +16,15 @@ module.exports = {
   ],
 
   rules: {
-    'jsx-quotes': [ error, 'prefer-double' ],   
-    'react/forbid-prop-types': [ error, { forbid: [ any ] } ],
+    'jsx-quotes': [ error, 'prefer-double' ],
+    'space-before-function-paren': [ error, { 'named': always } ],
     'no-multiple-empty-lines': [ error, { max: 1 } ],
+    'react/forbid-prop-types': [ error, { forbid: [ any ] } ],
     'react/jsx-boolean-value': [ off ],
     'react/jsx-indent': [ warn, 2 ],
     'react/jsx-indent-props': [ warn, 2 ],
     'react/jsx-pascal-case': error,
-    'react/jsx-tag-spacing': [ error, { 'beforeSelfClosing': 'always' } ],
+    'react/jsx-tag-spacing': [ error, { 'beforeSelfClosing': always } ],
     'react/sort-comp': [ error, {
       order: [
         'static-methods',


### PR DESCRIPTION
Added the [`space-before-function-paren`](https://eslint.org/docs/rules/space-before-function-paren) rule.

This rule will disallow `named` functions to be written like this

```
function foo () {}
```

This rule will require named functions to be written like this

```
function foo() {}

function foo(arg1, arg2) {}
```

[![](https://api.gh-polls.com/poll/01CCG932P3CKFJT822XPQ1K0TX/Yes)](https://api.gh-polls.com/poll/01CCG932P3CKFJT822XPQ1K0TX/Yes/vote)
[![](https://api.gh-polls.com/poll/01CCG932P3CKFJT822XPQ1K0TX/No)](https://api.gh-polls.com/poll/01CCG932P3CKFJT822XPQ1K0TX/No/vote) 