### PR TITLE
Allow multi spaces in variable declaration

### DIFF
--- a/node.js
+++ b/node.js
@@ -32,7 +32,7 @@ module.exports = {
   },
 
   rules: {
-    'no-multi-spaces': error,
+    'no-multi-spaces': [ error, { exceptions: { VariableDeclarator: true } } ],
     'no-useless-constructor': error,
     'space-infix-ops': error,
     'comma-dangle': [ warn, never ],

--- a/node.js
+++ b/node.js
@@ -52,7 +52,7 @@ module.exports = {
     'eol-last': [ error, always ],
     'brace-style': [ error, '1tbs', { allowSingleLine: false } ],
     'curly': [ error, all ],
-    'block-spacing': [ error,  always ],
+    'block-spacing': [ error, always ],
     'indent': [ error, 2, { SwitchCase: 1 } ],
     'spaced-comment': [ error, always ],
     'array-callback-return': warn,

--- a/react.js
+++ b/react.js
@@ -16,7 +16,7 @@ module.exports = {
   ],
 
   rules: {
-    'jsx-quotes': [ error, 'prefer-double' ],   
+    'jsx-quotes': [ error, 'prefer-double' ],
     'react/forbid-prop-types': [ error, { forbid: [ any ] } ],
     'no-multiple-empty-lines': [ error, { max: 1 } ],
     'react/jsx-boolean-value': [ off ],


### PR DESCRIPTION
This allows multiple spaces in variable declarations:
```js
const john   = 'John'
const paul   = 'Paul'
const george = 'George'
const ringo  = 'Ringo'
```
which currently needs to look like this because of the rule `no-multi-spaces`:
```js
const john = 'John'
const paul = 'Paul'
const george = 'George'
const ringo = 'Ringo'
```
https://eslint.org/docs/rules/no-multi-spaces#exceptions

[![](https://api.gh-polls.com/poll/01CDJ2BF12QBE3Z9G5VC6DAMR0/Yes)](https://api.gh-polls.com/poll/01CDJ2BF12QBE3Z9G5VC6DAMR0/Yes/vote)
[![](https://api.gh-polls.com/poll/01CDJ2BF12QBE3Z9G5VC6DAMR0/No)](https://api.gh-polls.com/poll/01CDJ2BF12QBE3Z9G5VC6DAMR0/No/vote)