### PR TITLE
Allowing statements on the same line only in React

### DIFF
--- a/node.js
+++ b/node.js
@@ -50,7 +50,7 @@ module.exports = {
     'space-before-function-paren': off,
     'keyword-spacing': error,
     'eol-last': [ error, always ],
-    'brace-style': [ error, '1tbs', { allowSingleLine: false } ],
+    'brace-style': [ error, '1tbs', { allowSingleLine: true } ],
     'curly': [ error, all ],
     'block-spacing': [ error,  always ],
     'indent': [ error, 2, { SwitchCase: 1 } ],

--- a/node.js
+++ b/node.js
@@ -50,7 +50,7 @@ module.exports = {
     'space-before-function-paren': off,
     'keyword-spacing': error,
     'eol-last': [ error, always ],
-    'brace-style': [ error, '1tbs', { allowSingleLine: true } ],
+    'brace-style': [ error, '1tbs', { allowSingleLine: false } ],
     'curly': [ error, all ],
     'block-spacing': [ error,  always ],
     'indent': [ error, 2, { SwitchCase: 1 } ],

--- a/react.js
+++ b/react.js
@@ -16,7 +16,8 @@ module.exports = {
   ],
 
   rules: {
-    'jsx-quotes': [ error, 'prefer-double' ],   
+    'brace-style': [ error, '1tbs', { allowSingleLine: true } ],
+    'jsx-quotes': [ error, 'prefer-double' ],
     'react/forbid-prop-types': [ error, { forbid: [ any ] } ],
     'no-multiple-empty-lines': [ error, { max: 1 } ],
     'react/jsx-boolean-value': [ off ],


### PR DESCRIPTION
This change refers to this [rule](https://eslint.org/docs/rules/brace-style)

As it is now, it is not allowed for a method to be passed in this way

```js
<Component someFunction={() => { doSomething(); doSomethingElse() }} />
```

With the proposed change, the example above would become correct.

In a `react` context at least, I believe it make more sense to allow this, as opposed to writing the more verbose

```js
<Component someFunction={() => {
        doSomething()
        doSomethingElse()
    }}
/>
```

---

[![](https://api.gh-polls.com/poll/01CDMRK0JPJQ13512S9F5EGQ99/Yes)](https://api.gh-polls.com/poll/01CDMRK0JPJQ13512S9F5EGQ99/Yes/vote)
[![](https://api.gh-polls.com/poll/01CDMRK0JPJQ13512S9F5EGQ99/No)](https://api.gh-polls.com/poll/01CDMRK0JPJQ13512S9F5EGQ99/No/vote)