### PR TITLE
Adding strict rules for space-before-function-paren.

### DIFF
--- a/node.js
+++ b/node.js
@@ -44,7 +44,7 @@ module.exports = {
     'array-bracket-spacing': [ error, always ],
     'quotes': [ error, single ],
     'semi': [ error, never ],
-    'space-before-function-paren': off,
+    'space-before-function-paren': [ error, { anonymous: always, named: never, asyncArrow: always } ],
     'keyword-spacing': error,
     'eol-last': [ error, always ],
     'brace-style': [ error, '1tbs', { allowSingleLine: false } ],


### PR DESCRIPTION
https://eslint.org/docs/rules/space-before-function-paren

fixable with `--fix`.

Ok:
```
function foo() {}
class Foo {
  static foo() {}
  foo() {}
}
async () => null
function () {}
```

Error:
```
function foo () {}
class Foo {
  static foo () {}
  foo () {}
}
async() => null
function() {}
```

[![](https://api.gh-polls.com/poll/01CY201XXHMNRB09H7SSGC6NBR/Yes)](https://api.gh-polls.com/poll/01CY201XXHMNRB09H7SSGC6NBR/Yes/vote)
[![](https://api.gh-polls.com/poll/01CY201XXHMNRB09H7SSGC6NBR/No)](https://api.gh-polls.com/poll/01CY201XXHMNRB09H7SSGC6NBR/No/vote)