### PR TITLE
Allow flow comments.

### DIFF
--- a/node.js
+++ b/node.js
@@ -51,7 +51,7 @@ module.exports = {
     'curly': [ error, all ],
     'block-spacing': [ error,  always ],
     'indent': [ error, 2, { SwitchCase: 1 } ],
-    'spaced-comment': [ error, always ],
+    'spaced-comment': [ error, always, { "markers": [ ":", "::" ] } ],
     'array-callback-return': warn,
     'eqeqeq': [ error, always, { null: 'ignore' } ],
     'yoda': error,


### PR DESCRIPTION
Currently we disallow `/*foo*/` comments which require spaces `/* foo */`, which is great but it breaks flow type annotations in comments, ie: `/*: string */`.

This change allows for two markers used by flow comments so those annotations will be accepted:

```
function foo(a /*: string */) { ... }
function foo(a /*:: ?: string */ = 'myDefault') { ... }
```