### PR TITLE
Adding exception to yoda for ranges.

### DIFF
--- a/node.js
+++ b/node.js
@@ -54,7 +54,7 @@ module.exports = {
     'spaced-comment': [ error, always, { "markers": [ ":", "::" ] } ],
     'array-callback-return': warn,
     'eqeqeq': [ error, always, { null: 'ignore' } ],
-    'yoda': error,
+    'yoda': [ error, { exceptRange: true } ],
     'no-throw-literal': error,
     'no-self-compare': error,
     'no-return-assign': error,

--- a/node.js
+++ b/node.js
@@ -54,7 +54,7 @@ module.exports = {
     'spaced-comment': [ error, always, { "markers": [ ":", "::" ] } ],
     'array-callback-return': warn,
     'eqeqeq': [ error, always, { null: 'ignore' } ],
-    'yoda': [ error, { exceptRange: true } ],
+    'yoda': [ error, never, { exceptRange: true } ],
     'no-throw-literal': error,
     'no-self-compare': error,
     'no-return-assign': error,


### PR DESCRIPTION
This change allows for range tests.

--fix'able.

Old:
```
(0 <= foo && foo <= 1) // error
```

New:
```
(0 <= foo && foo <= 1) // ok
```

[![](https://api.gh-polls.com/poll/01CYGZYE41AGECTYBP8GN8SC4R/Yes)](https://api.gh-polls.com/poll/01CYGZYE41AGECTYBP8GN8SC4R/Yes/vote)
[![](https://api.gh-polls.com/poll/01CYGZYE41AGECTYBP8GN8SC4R/No)](https://api.gh-polls.com/poll/01CYGZYE41AGECTYBP8GN8SC4R/No/vote)
