### PR TITLE
Removing obsolete valid-jsdoc rule.

### DIFF
--- a/node.js
+++ b/node.js
@@ -59,7 +59,6 @@ module.exports = {
     'no-self-compare': error,
     'no-return-assign': error,
     'no-loop-func': error,
-    'valid-jsdoc': [ warn, { requireParamDescription: false, requireReturnDescription: false } ],
     'for-direction': error,
     'no-buffer-constructor': error,
     'no-new-require': error,


### PR DESCRIPTION
`valid-jsdoc` rule has been deprecated https://eslint.org/docs/rules/valid-jsdoc

[![](https://api.gh-polls.com/poll/01D15SNHDYGPTBMM2M274247H2/Yes)](https://api.gh-polls.com/poll/01D15SNHDYGPTBMM2M274247H2/Yes/vote)
[![](https://api.gh-polls.com/poll/01D15SNHDYGPTBMM2M274247H2/No)](https://api.gh-polls.com/poll/01D15SNHDYGPTBMM2M274247H2/No/vote)
