### PR TITLE
Allow props for params reassign

### DIFF
--- a/node.js
+++ b/node.js
@@ -57,7 +57,7 @@ module.exports = {
     'no-mixed-spaces-and-tabs': error,
     'no-multi-spaces': error,
     'no-new-require': error,
-    'no-param-reassign': [ error, { props: true } ],
+    'no-param-reassign': [ error, { props: false } ],
     'no-path-concat': error,
     'no-return-assign': error,
     'no-self-compare': error,


### PR DESCRIPTION
Otherwise with koa context (`ctx`) it's too tedious.

I'm happy to use `ignorePropertyModificationsFor` and whitelist `ctx` and other common names as a strictier alternative

infos:
- https://eslint.org/docs/rules/no-param-reassign
- https://github.com/airbnb/javascript/issues/1217#issuecomment-284877791